### PR TITLE
LIBHYDRA-347. Repeatable LabeledThing subject handling.

### DIFF
--- a/app/helpers/resource_helper.rb
+++ b/app/helpers/resource_helper.rb
@@ -29,6 +29,9 @@ module ResourceHelper
               args[:sameAs] = obj[same_as_predicate]&.first || ''
             end
           end
+          # remove the value, so that the component will apply the defaultProps
+          # if there is no value for this field
+          args.delete(:value) if args[:value].empty?
         end
 
         # special case for access level

--- a/app/javascript/components/LabeledThing.jsx
+++ b/app/javascript/components/LabeledThing.jsx
@@ -2,7 +2,7 @@ import React from "react"
 import PropTypes from "prop-types"
 import URIRef from "./URIRef";
 import PlainLiteral from "./PlainLiteral";
-import uuid from "uuid"
+import { v4 as uuid } from "uuid"
 
 const labelPredicate = 'http://www.w3.org/2000/01/rdf-schema#label';
 const sameAsPredicate = 'http://www.w3.org/2002/07/owl#sameAs';
@@ -17,6 +17,9 @@ class LabeledThing extends React.Component {
     let value = props.value
 
     this.subject = value['value']['@id'];
+    if (this.subject === '') {
+      this.subject = props.paramPrefix + '#' + uuid();
+    }
 
     // Modify subject with "key" value when used via "Repeatable"
     this.index = props.value["key"];
@@ -70,7 +73,7 @@ LabeledThing.propTypes = {
 
 LabeledThing.defaultProps = {
   value: {
-    value: { '@id': `labeled-thing-${uuid("labeled-thing")}-` },
+    value: { '@id': '' },
     label: { '@value': '', '@language': '' },
     sameAs: { '@id': '' },
   }

--- a/app/views/react_components/react_components.html.erb
+++ b/app/views/react_components/react_components.html.erb
@@ -89,13 +89,9 @@
         componentType: :LabeledThing,
         paramPrefix: "repeatable_labeled_thing",
         name: 'repeatableLabeledThingPredicate',
-        defaultValue: {
-            value: {'@id': 'subjectURI#newUUID'},
-        }
       }
     )%>
-
-
+  </div>
 
   <h3>Repeatable PlainLiteral</h3>
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react_ujs": "^2.6.1"
+    "react_ujs": "^2.6.1",
+    "uuid": "^8.2.0"
   },
   "devDependencies": {
     "react-styleguidist": "^11.0.8",


### PR DESCRIPTION
- Default subject for new LabeledThing generates a new v4 UUID.
- If there is no value set for a field, remove the value property on the Ruby side, so that React can fill in its default properties.
- Added uuid module to the package.json
- Removed defaultValue from the react components example

https://issues.umd.edu/browse/LIBHYDRA-347